### PR TITLE
add gum as an alternative for the base command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
 	"name": "gumption",
 	"version": "0.0.0",
 	"license": "MIT",
-	"bin": "dist/cli.js",
+	"bin": {
+		"gumption": "dist/cli.js",
+		"gum": "dist/cli.js"
+	},
 	"type": "module",
 	"engines": {
 		"node": ">=16"


### PR DESCRIPTION
You'll have to rerun `npm link` when this is merged. Adds `gum` as our short command

Closes #4 